### PR TITLE
Make ChatBox height responsive

### DIFF
--- a/src/components/ChatBox.tsx
+++ b/src/components/ChatBox.tsx
@@ -148,7 +148,7 @@ const ChatBox: React.FC = () => {
         </h2>
         
         <div className="glass-card rounded-2xl overflow-hidden shadow-glow">
-          <div className="h-[500px] overflow-y-auto p-6 space-y-6">
+          <div className="h-[70vh] md:h-[500px] overflow-y-auto p-6 space-y-6">
             {messages.length === 0 ? (
               <div className="text-center text-gray-500 mt-8 animate-fade-in">
                 <p className="text-lg mb-4">


### PR DESCRIPTION
## Summary
- adjust chat container height to be responsive

## Testing
- `npm run lint`
- `npm run build`

Visual check of scrolling was not possible in this environment.

------
https://chatgpt.com/codex/tasks/task_e_68409e6429a48321a88352df001ca089