### PR TITLE
Load and persist thread id in ChatBox

### DIFF
--- a/src/components/ChatBox.tsx
+++ b/src/components/ChatBox.tsx
@@ -34,12 +34,25 @@ const ChatBox: React.FC = () => {
       }
     }
 
-    createThread();
+    const savedThreadId = localStorage.getItem('threadId');
+    if (savedThreadId) {
+      setThreadId(savedThreadId);
+    } else {
+      createThread();
+    }
   }, []);
 
   useEffect(() => {
     localStorage.setItem('chatMessages', JSON.stringify(messages));
   }, [messages]);
+
+  useEffect(() => {
+    if (threadId) {
+      localStorage.setItem('threadId', threadId);
+    } else {
+      localStorage.removeItem('threadId');
+    }
+  }, [threadId]);
 
   const createThread = async () => {
     try {
@@ -121,6 +134,7 @@ const ChatBox: React.FC = () => {
   const handleNewConversation = () => {
     setMessages([]);
     localStorage.removeItem('chatMessages');
+    localStorage.removeItem('threadId');
     setThreadId(null);
     createThread();
   };


### PR DESCRIPTION
## Summary
- remember `threadId` across sessions using `localStorage`
- clear stored `threadId` when starting a new conversation

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840a70121bc83219551791d857cf6e2