### PR TITLE
Update hero section layout

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,33 +1,39 @@
 import React from 'react';
 import Typewriter from 'typewriter-effect';
+import { Bot } from 'lucide-react';
 
 const HeroSection: React.FC = () => (
-  <section className="text-center py-16 px-6 bg-gradient-to-b from-indigo-50 to-white">
-    <div className="max-w-4xl mx-auto space-y-6">
-      <h1 className="text-4xl md:text-5xl font-extrabold text-gray-900 leading-snug tracking-tight">
-        Masz pytanie o karierę?{' '}
-        <span className="text-indigo-600">
-          <Typewriter
-            options={{
-              strings: ['CareerGPT zna odpowiedź – po polsku i po ludzku.'],
-              autoStart: true,
-              loop: false,
-              delay: 50,
-              cursor: '|',
-              deleteSpeed: 999999999 // Effectively prevents deletion
-            }}
-          />
-        </span>
-      </h1>
-      <p className="text-lg text-gray-700 max-w-2xl mx-auto leading-relaxed">
-        Nie musisz znać się na AI. Wystarczy, że zapytasz. CareerGPT to Twój osobisty doradca zawodowy, który rozumie stres rekrutacji, polskie realia i nie używa HR-owego bełkotu.
-      </p>
-      <a
-        href="#chat"
-        className="inline-block bg-indigo-600 text-white px-6 py-3 rounded-full text-lg font-medium shadow hover:bg-indigo-700 hover:shadow-lg transition transform hover:scale-105"
-      >
-        Zacznij rozmowę
-      </a>
+  <section className="py-16 px-6 bg-gradient-to-b from-indigo-50 to-white">
+    <div className="max-w-7xl mx-auto grid items-center gap-8 md:grid-cols-2">
+      <div className="space-y-6 text-center md:text-left">
+        <h1 className="text-4xl md:text-5xl font-extrabold text-gray-900 leading-snug tracking-tight">
+          Masz pytanie o karierę?{' '}
+          <span className="text-indigo-600">
+            <Typewriter
+              options={{
+                strings: ['Kariera w trybie turbo z CareerGPT.'],
+                autoStart: true,
+                loop: false,
+                delay: 50,
+                cursor: '|',
+                deleteSpeed: 999999999,
+              }}
+            />
+          </span>
+        </h1>
+        <p className="text-lg text-gray-700 leading-relaxed">
+          Nie musisz znać się na AI. Wystarczy, że zapytasz. CareerGPT to Twój osobisty doradca zawodowy, który rozumie stres rekrutacji i polskie realia.
+        </p>
+        <a
+          href="#chat"
+          className="inline-block bg-indigo-600 text-white px-6 py-3 rounded-full text-lg font-medium shadow hover:bg-indigo-700 hover:shadow-lg transition transform hover:scale-105"
+        >
+          Zacznij rozmowę
+        </a>
+      </div>
+      <div className="flex justify-center md:justify-end">
+        <Bot className="w-48 h-48 text-indigo-600" />
+      </div>
     </div>
   </section>
 );


### PR DESCRIPTION
## Summary
- switch hero to a two-column layout
- add a Bot SVG from lucide-react
- tweak tagline for the typewriter effect

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841d37db4ac83219850856205fb7c52