### PR TITLE
Update header link text to Polish

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -10,7 +10,7 @@ const Header: React.FC = () => (
         href="#chat"
         className="text-sm font-medium text-indigo-600 hover:text-indigo-800 transition"
       >
-        Zadaj pytanie
+        Zacznij teraz
       </a>
     </div>
   </header>


### PR DESCRIPTION
## Summary
- tweak header link text to `Zacznij teraz`
- anchor still scrolls to `#chat`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841d38936e48321a3d11247f6ab2550