### PR TITLE
Add entry animations with framer-motion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vite-react-typescript-starter",
       "version": "0.0.0",
       "dependencies": {
+        "framer-motion": "^11.18.2",
         "lucide-react": "^0.344.0",
         "openai": "^4.28.0",
         "react": "^18.3.1",
@@ -2749,6 +2750,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4337,6 +4365,21 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -5535,6 +5578,12 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "framer-motion": "^11.18.2",
     "lucide-react": "^0.344.0",
     "openai": "^4.28.0",
     "react": "^18.3.1",

--- a/src/components/ChatBox.tsx
+++ b/src/components/ChatBox.tsx
@@ -3,6 +3,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeHighlight from 'rehype-highlight';
 import { Send, Loader2 } from 'lucide-react';
+import { motion } from 'framer-motion';
 
 interface Message {
   role: 'user' | 'assistant';
@@ -225,7 +226,14 @@ const ChatBox: React.FC = () => {
   };
 
   return (
-    <section id="chat" className="py-8 px-6">
+    <motion.section
+      id="chat"
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.5 }}
+      className="py-8 px-6"
+    >
       <div className="max-w-3xl mx-auto">
         <h2 className="text-3xl font-bold text-center mb-4 animate-fade-up">
           Porozmawiaj z CareerGPT
@@ -334,7 +342,7 @@ const ChatBox: React.FC = () => {
           </form>
         </div>
       </div>
-    </section>
+    </motion.section>
   );
 };
 

--- a/src/components/FeatureCards.tsx
+++ b/src/components/FeatureCards.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { motion } from 'framer-motion';
 
 const features = [
   {
@@ -25,12 +26,22 @@ const features = [
 
 const FeatureCards: React.FC = () => {
   return (
-    <section className="py-12 bg-gray-50">
+    <motion.section
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.5 }}
+      className="py-12 bg-gray-50"
+    >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
           {features.map((feature, index) => (
-            <div 
+            <motion.div
               key={index}
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.4, delay: index * 0.1 }}
               className="bg-white rounded-xl shadow-md p-6 hover:shadow-lg transition-shadow duration-300"
             >
               <div className="flex justify-center items-center mb-4">
@@ -38,11 +49,11 @@ const FeatureCards: React.FC = () => {
               </div>
               <h3 className="text-xl font-semibold mb-3 text-center">{feature.title}</h3>
               <p className="text-gray-600 text-center">{feature.description}</p>
-            </div>
+            </motion.div>
           ))}
         </div>
       </div>
-    </section>
+    </motion.section>
   );
 };
 

--- a/src/components/ForWhom.tsx
+++ b/src/components/ForWhom.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
+import { motion } from 'framer-motion';
 
 const ForWhom: React.FC = () => (
-  <section className="bg-white py-16 px-6">
+  <motion.section
+    initial={{ opacity: 0, y: 20 }}
+    whileInView={{ opacity: 1, y: 0 }}
+    viewport={{ once: true }}
+    transition={{ duration: 0.5 }}
+    className="bg-white py-16 px-6"
+  >
     <div className="max-w-4xl mx-auto">
       <h2 className="text-3xl md:text-4xl font-extrabold text-gray-900 mb-6 text-center">
         To Ty?
@@ -43,7 +50,7 @@ const ForWhom: React.FC = () => (
         </div>
       </div>
     </div>
-  </section>
+  </motion.section>
 );
 
 export default ForWhom

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,8 +1,15 @@
 import React from 'react';
 import Typewriter from 'typewriter-effect';
+import { motion } from 'framer-motion';
 
 const HeroSection: React.FC = () => (
-  <section className="text-center py-16 px-6 bg-gradient-to-b from-indigo-50 to-white">
+  <motion.section
+    initial={{ opacity: 0, y: 20 }}
+    whileInView={{ opacity: 1, y: 0 }}
+    viewport={{ once: true }}
+    transition={{ duration: 0.5 }}
+    className="text-center py-16 px-6 bg-gradient-to-b from-indigo-50 to-white"
+  >
     <div className="max-w-4xl mx-auto space-y-6">
       <h1 className="text-4xl md:text-5xl font-extrabold text-gray-900 leading-snug tracking-tight">
         Masz pytanie o karierę?{' '}
@@ -29,7 +36,7 @@ const HeroSection: React.FC = () => (
         Zacznij rozmowę
       </a>
     </div>
-  </section>
+  </motion.section>
 );
 
 export default HeroSection;

--- a/src/components/HowItWorks.tsx
+++ b/src/components/HowItWorks.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { motion } from 'framer-motion';
 
 const steps = [
   {
@@ -19,7 +20,13 @@ const steps = [
 ];
 
 const HowItWorks: React.FC = () => (
-  <section className="py-16 px-6 bg-white">
+  <motion.section
+    initial={{ opacity: 0, y: 20 }}
+    whileInView={{ opacity: 1, y: 0 }}
+    viewport={{ once: true }}
+    transition={{ duration: 0.5 }}
+    className="py-16 px-6 bg-white"
+  >
     <div className="max-w-6xl mx-auto text-center">
       <h2 className="text-3xl md:text-4xl font-extrabold text-gray-900 mb-6">Jak to działa?</h2>
       <p className="text-lg text-gray-600 mb-12 max-w-2xl mx-auto">
@@ -37,7 +44,7 @@ const HowItWorks: React.FC = () => (
         ))}
       </div>
     </div>
-  </section>
+  </motion.section>
 );
 
 export default HowItWorks;


### PR DESCRIPTION
## Summary
- install `framer-motion`
- animate `HeroSection` entry
- animate `ForWhom` section
- animate `FeatureCards` and each card
- animate `HowItWorks` section
- animate chat section

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841d3c22d0c832193b14442f2e765e2