### PR TITLE
Update CORS headers for Supabase functions

### DIFF
--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -3,6 +3,7 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
 }
 
 serve(async (req) => {

--- a/supabase/functions/create-thread/index.ts
+++ b/supabase/functions/create-thread/index.ts
@@ -3,6 +3,7 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
 }
 
 serve(async (req) => {


### PR DESCRIPTION
## Summary
- update CORS configuration in `chat` and `create-thread` functions

## Testing
- `npm run lint` *(fails: 'e' is defined but never used in ChatBox.tsx)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684a94f654a08321bb349756278739e5