### PR TITLE
Fix hero heading color

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -10,7 +10,7 @@ const HeroSection: React.FC = () => (
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.8 }}
     >
-      <h1 className="text-4xl md:text-5xl font-extrabold text-gray-9000 leading-snug tracking-tight">
+      <h1 className="text-4xl md:text-5xl font-extrabold text-gray-900 leading-snug tracking-tight">
         Masz pytanie o karierę?{' '}
         <span className="text-indigo-600">
           <Typewriter


### PR DESCRIPTION
## Summary
- fix typo in hero heading text color class name

## Testing
- `npm run lint` *(fails: cannot pass existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684a94efc5d48321b697be20dec54fd4