### PR TITLE
Fix text overflow in chat

### DIFF
--- a/src/components/ChatBox.tsx
+++ b/src/components/ChatBox.tsx
@@ -22,7 +22,6 @@ const ChatBox: React.FC = () => {
   const reduceMotion = useReducedMotion();
   const chatEndRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const initialScroll = useRef(true);
 
   // URL do naszych Edge Functions
   const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
@@ -34,13 +33,8 @@ const ChatBox: React.FC = () => {
       textarea.style.height = 'auto';
       textarea.style.height = `${Math.min(textarea.scrollHeight, 200)}px`;
     }
-  };
 
-  const scrollToBottom = () => {
-    chatEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   };
-
-  
 
   useEffect(() => {
     const saved = localStorage.getItem('chatMessages');

--- a/src/index.css
+++ b/src/index.css
@@ -59,6 +59,7 @@
 /* Ulepszone style dla prose w czacie */
 .prose-enhanced {
   @apply max-w-none;
+  overflow-wrap: anywhere;
 }
 
 .prose-enhanced p {
@@ -116,6 +117,7 @@
 /* Style dla wiadomości użytkownika */
 .prose-invert {
   @apply max-w-none;
+  overflow-wrap: anywhere;
 }
 
 .prose-invert p {


### PR DESCRIPTION
## Summary
- wrap long text inside chat bubbles by adding `overflow-wrap: anywhere` to `.prose-enhanced` and `.prose-invert`
- clean up unused variables in `ChatBox.tsx` so lint passes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684adf75c9808321bd11695e7a06bf25